### PR TITLE
Add AppVersion component to display build version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,8 @@ jobs:
       - run: |
           pnpm install --prefer-offline --frozen-lockfile
       - run: |
+          echo "NUXT_PUBLIC_BUILD_SHA=$(git rev-parse --short HEAD)" | tee -a ${GITHUB_ENV}
+      - run: |
           NUXT_APP_BASE_URL=/${{ github.event.repository.name }}/ pnpm build
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/app.vue
+++ b/app.vue
@@ -8,7 +8,10 @@ const data = ref<Datum[] | null>(null);
 <template>
   <div class="container d-flex flex-column gap-3">
     <header class="d-flex justify-content-center">
-      <h1><FontAwesomeIcon :icon="faSun" />&nbsp;Daylight visualizer</h1>
+      <h1>
+        <FontAwesomeIcon :icon="faSun" />&nbsp;Daylight visualizer
+        <AppVersion />
+      </h1>
     </header>
     <div class="row">
       <CoordinatesForm
@@ -27,3 +30,9 @@ const data = ref<Datum[] | null>(null);
     </div>
   </div>
 </template>
+
+<style scoped lang="scss">
+h1 {
+  position: relative;
+}
+</style>

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -1,4 +1,5 @@
 $base-sun-color: #f5f523 !default;
 $font-family-sans-serif: 'Oxygen', sans-serif !default;
+$font-family-monospace: 'Fira Mono', monospace !default;
 $headings-font-family: 'Palanquin', sans-serif !default;
 $enable-validation-icons: false !default;

--- a/components/AppVersion.vue
+++ b/components/AppVersion.vue
@@ -1,0 +1,17 @@
+<script setup lang="ts">
+const { buildSha: version } = useRuntimeConfig().public;
+</script>
+
+<template>
+  <span class="font-monospace">v{{ version }}</span>
+</template>
+
+<style scoped lang="scss">
+span {
+  position: absolute;
+  right: 0;
+  bottom: -1.25rem;
+  font-weight: normal;
+  font-size: .75rem;
+}
+</style>

--- a/components/ChartVisual.vue
+++ b/components/ChartVisual.vue
@@ -109,5 +109,3 @@ const chartOptions = computed<Options>(() => {
     />
   </div>
 </template>
-
-<style scoped></style>

--- a/components/CoordinatesForm.vue
+++ b/components/CoordinatesForm.vue
@@ -244,5 +244,3 @@ watch(data, (newValue) => {
     </form>
   </div>
 </template>
-
-<style scoped></style>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -45,6 +45,11 @@ export default defineNuxtConfig({
     },
   },
   css: ['~/assets/main.scss'],
+  runtimeConfig: {
+    public: {
+      buildSha: 'dev',
+    },
+  },
   compatibilityDate: '2024-11-01',
   postcss: {
     plugins: {


### PR DESCRIPTION
Introduced a new `AppVersion` component to show the build version using the `buildSha` from runtime configuration. Updated global SCSS variables to include a monospace font for styling and adjusted application layout. This change improves transparency in app deployments by displaying the version visibly in the UI.