### PR TITLE
Remove dawn and dusk data and related functionality

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -2,4 +2,3 @@
 @import "styles/highcharts";
 @import "styles/bootstrap";
 @import "styles/tooltip";
-@import "styles/font-awesome";

--- a/assets/styles/_css-variables.scss
+++ b/assets/styles/_css-variables.scss
@@ -2,7 +2,4 @@
 
 :root {
   --dv-chart-color-0: #{$base-sun-color};
-  --dv-chart-color-1: #{desaturate($base-sun-color, 10%)};
-  --dv-chart-color-2: #{desaturate($base-sun-color, 15%)};
-  --dv-chart-color-3: #{desaturate($base-sun-color, 20%)};
 }

--- a/assets/styles/_font-awesome.scss
+++ b/assets/styles/_font-awesome.scss
@@ -1,1 +1,0 @@
-@import '@fortawesome/fontawesome-svg-core/styles.css';

--- a/assets/styles/_highcharts.scss
+++ b/assets/styles/_highcharts.scss
@@ -1,8 +1,5 @@
 :root, .highcharts-light {
   --highcharts-color-0: var(--dv-chart-color-0);
-  --highcharts-color-1: var(--dv-chart-color-1);
-  --highcharts-color-3: var(--dv-chart-color-2);
-  --highcharts-color-2: var(--dv-chart-color-3);
 }
 
 .highcharts-root {

--- a/components/ChartVisual.vue
+++ b/components/ChartVisual.vue
@@ -5,101 +5,69 @@ import { DateTime } from 'luxon';
 const { t } = useI18n();
 const props = defineProps<{ data: Datum[] }>();
 
-const chartOptions = computed<Options>(() => {
-  const sanitizedData = props.data.filter(
-    d => d.dawn && d.sunrise && d.sunset && d.dusk,
-  );
-  const min = Math.min(...sanitizedData.map(d => d.dawn));
-  const max = Math.max(...sanitizedData.map(d => d.dusk));
-  return {
-    accessibility: {
-      enabled: false,
-    },
-    boost: {
-      enabled: true,
-    },
-    chart: {
-      polar: true,
-      styledMode: true,
-    },
-    credits: {
-      href: 'https://sunrisesunset.io/',
-      text: 'Powered by SunriseSunset.io',
-    },
-    plotOptions: {
-      series: {
-        marker: {
-          enabled: false,
-        },
+const chartOptions = computed<Options>(() => ({
+  accessibility: {
+    enabled: false,
+  },
+  boost: {
+    enabled: true,
+  },
+  chart: {
+    polar: true,
+    styledMode: true,
+  },
+  credits: {
+    href: 'https://sunrisesunset.io/',
+    text: 'Powered by SunriseSunset.io',
+  },
+  plotOptions: {
+    series: {
+      marker: {
+        enabled: false,
       },
     },
-    series: [
-      {
-        id: 'dusk',
-        name: t('chart.labels.dusk'),
-        type: 'areaspline',
-        data: sanitizedData.map(d => ({
-          x: d.date,
-          y: d.dusk,
-        })),
-      },
-      {
-        id: 'sunset',
-        name: t('chart.labels.sunset'),
-        type: 'areaspline',
-        data: sanitizedData.map(d => ({
-          x: d.date,
-          y: d.sunset,
-        })),
-      },
-      {
-        id: 'sunrise',
-        name: t('chart.labels.sunrise'),
-        type: 'areaspline',
-        data: sanitizedData.map(d => ({
-          x: d.date,
-          y: d.sunrise,
-        })),
-      },
-      {
-        id: 'dawn',
-        name: t('chart.labels.dawn'),
-        type: 'areaspline',
-        data: sanitizedData.map(d => ({
-          x: d.date,
-          y: d.dawn,
-        })),
-      },
-    ],
-    time: {
-      timezone: undefined,
+  },
+  series: [
+    {
+      id: 'sunset',
+      name: t('chart.labels.daylight'),
+      type: 'arearange',
+      linecap: 'round',
+      data: props.data.filter(
+        d => d.sunrise != null && d.sunset != null,
+      ).map(d => ({
+        x: d.date,
+        low: d.sunrise,
+        high: d.sunset,
+      })),
     },
-    title: {
-      text: '',
+  ],
+  time: {
+    timezone: undefined,
+  },
+  title: {
+    text: '',
+  },
+  tooltip: {
+    pointFormatter: function () {
+      return `
+<span class="highcharts-strong">${t('chart.labels.sunrise')}: ${DateTime.fromMillis(
+    this.low!,
+  ).toFormat('HH:mm')}</span><br/>
+<span class="highcharts-strong">${t('chart.labels.sunset')}: ${DateTime.fromMillis(
+    this.high!,
+  ).toFormat('HH:mm')}</span>
+`;
     },
-    tooltip: {
-      pointFormatter: function () {
-        return `
-<span class="highcharts-color-${this.colorIndex}">&#9679;</span>
-<span>&nbsp;${this.series.name}:&nbsp;</span>
-<span class="highcharts-strong">${DateTime.fromMillis(this.x + (this.y ?? 0)).toFormat(
-  'HH:mm:ss',
-)}</span>
-<br/>`;
-      },
-      shared: true,
-    },
-    xAxis: {
-      type: 'datetime',
-    },
-    yAxis: {
-      type: 'datetime',
-      min,
-      max,
-      labels: { format: '{value:%H:%M}' },
-    },
-  };
-});
+  },
+  xAxis: {
+    type: 'datetime',
+  },
+  yAxis: {
+    type: 'datetime',
+    labels: { format: '{value:%H:%M}' },
+  },
+}));
 </script>
 
 <template>

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -16,8 +16,7 @@ export default {
   },
   chart: {
     labels: {
-      dusk: 'Dusk',
-      dawn: 'Dawn',
+      daylight: 'Daylight',
       sunrise: 'Sunrise',
       sunset: 'Sunset',
     },

--- a/i18n/locales/nl.ts
+++ b/i18n/locales/nl.ts
@@ -16,8 +16,7 @@ export default {
   },
   chart: {
     labels: {
-      dusk: 'Schemering',
-      dawn: 'Dageraad',
+      daylight: 'Daglicht',
       sunrise: 'Zonsopkomst',
       sunset: 'Zonsondergang',
     },

--- a/tests/e2e/chart.spec.ts
+++ b/tests/e2e/chart.spec.ts
@@ -89,13 +89,10 @@ test.describe('Chart', () => {
     );
     await submitButton.click();
     await page.waitForFunction(() =>
-      document.querySelectorAll('.highcharts-series').length === 4,
+      document.querySelectorAll('.highcharts-series').length === 1,
     );
     expect(page.locator('div.highcharts-light')).toBeDefined();
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Dusk');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-1 > text')).toBe('Sunset');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-2 > text')).toBe('Sunrise');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-3 > text')).toBe('Dawn');
+    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Daylight');
   });
 
   test('should fill data with geolocation api', async ({ page }) => {
@@ -122,12 +119,9 @@ test.describe('Chart -> Locale set to nl', () => {
     );
     await page.locator('button[type=submit]').click();
     await page.waitForFunction(() =>
-      document.querySelectorAll('.highcharts-series').length === 4,
+      document.querySelectorAll('.highcharts-series').length === 1,
     );
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Schemering');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-1 > text')).toBe('Zonsondergang');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-2 > text')).toBe('Zonsopkomst');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-3 > text')).toBe('Dageraad');
+    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Daglicht');
   });
 });
 
@@ -145,11 +139,8 @@ test.describe('Chart -> Locale set to non-supported language', () => {
     );
     await page.locator('button[type=submit]').click();
     await page.waitForFunction(() =>
-      document.querySelectorAll('.highcharts-series').length === 4,
+      document.querySelectorAll('.highcharts-series').length === 1,
     );
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Dusk');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-1 > text')).toBe('Sunset');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-2 > text')).toBe('Sunrise');
-    expect(await page.textContent('.highcharts-legend-item.highcharts-series-3 > text')).toBe('Dawn');
+    expect(await page.textContent('.highcharts-legend-item.highcharts-series-0 > text')).toBe('Daylight');
   });
 });

--- a/utils/datum.ts
+++ b/utils/datum.ts
@@ -1,7 +1,5 @@
 export type Datum = {
   date: number;
-  dawn: number;
-  dusk: number;
   sunrise: number;
   sunset: number;
   timezone: string;

--- a/utils/transform-data.ts
+++ b/utils/transform-data.ts
@@ -6,8 +6,6 @@ export default function (data: any): Datum[] {
         const date = DateTime.fromISO(d.date).toMillis();
         return {
           date,
-          dawn: parseDateField(d, 'dawn', date),
-          dusk: parseDateField(d, 'dusk', date),
           sunrise: parseDateField(d, 'sunrise', date),
           sunset: parseDateField(d, 'sunset', date),
           timezone: d.timezone,


### PR DESCRIPTION
This commit removes support for "dawn" and "dusk" data and references across the codebase, including chart visualizations, translations, styles, and tests. Streamlined implementation focuses only on "sunrise" and "sunset," simplifying the code and improving maintainability.