### PR TITLE
Add detailed validation and tooltips for start and end dates

### DIFF
--- a/components/CoordinatesForm.vue
+++ b/components/CoordinatesForm.vue
@@ -7,10 +7,14 @@ import { autoUpdate, offset, useFloating } from '@floating-ui/vue';
 const { meta, defineField, handleSubmit, errors, setFieldValue } = useForm({
   validationSchema: toTypedSchema(
     object({
-      latitude: number().required().min(-90).max(90),
-      longitude: number().required().min(-180).max(180),
-      startDate: string().required(),
-      endDate: string().required()
+      latitude: number()
+        .transform((value, _, ctx) => (!ctx.isType(value) ? null : value))
+        .required('is-required').min(-90, 'range').max(90, 'range'),
+      longitude: number()
+        .transform((value, _, ctx) => (!ctx.isType(value) ? null : value))
+        .required('is-required').min(-180, 'range').max(180, 'range'),
+      startDate: string().required('is-required'),
+      endDate: string().required('is-required')
         .test('is-after-start', 'is-after-start', (val, context) => {
           const start = DateTime.fromISO(context.parent.startDate);
           const end = DateTime.fromISO(val);
@@ -104,6 +108,14 @@ const { floatingStyles: longitudeTooltipStyles } = useFloating(longitudeInput, l
   middleware: [offset({ mainAxis: 10 })],
 });
 
+const startDateInput = ref<HTMLElement | null>(null);
+const startDateTooltip = ref<HTMLElement | null>(null);
+const { floatingStyles: startDateTooltipStyles } = useFloating(startDateInput, startDateTooltip, {
+  placement: 'top',
+  whileElementsMounted: autoUpdate,
+  middleware: [offset({ mainAxis: 10 })],
+});
+
 const endDateInput = ref<HTMLElement | null>(null);
 const endDateTooltip = ref<HTMLElement | null>(null);
 const { floatingStyles: endDateTooltipStyles } = useFloating(endDateInput, endDateTooltip, {
@@ -152,7 +164,7 @@ watch(data, (newValue) => {
             class="error-tooltip"
             :style="latitudeTooltipStyles"
           >
-            {{ $t('form.warnings.latitude') }}
+            {{ $t(`form.warnings.latitude.${errors.latitude}`) }}
           </span>
         </div>
         <div class="col-12 col-md-4">
@@ -175,7 +187,7 @@ watch(data, (newValue) => {
             class="error-tooltip"
             :style="longitudeTooltipStyles"
           >
-            {{ $t('form.warnings.longitude') }}
+            {{ $t(`form.warnings.longitude.${errors.longitude}`) }}
           </span>
         </div>
         <div class="col-auto d-flex flex-column justify-content-end">
@@ -207,12 +219,21 @@ watch(data, (newValue) => {
           >{{ $t('form.labels.startDate') }}</label>
           <input
             id="startDate"
+            ref="startDateInput"
             v-model="startDate"
             class="form-control"
             :class="{ 'is-invalid': errors.startDate }"
             type="date"
             v-bind="startDateAttrs"
           >
+          <span
+            v-if="errors.startDate"
+            ref="startDateTooltip"
+            class="error-tooltip"
+            :style="startDateTooltipStyles"
+          >
+            {{ $t(`form.warnings.startDate.${errors.startDate}`) }}
+          </span>
         </div>
         <div class="col-12 col-md-4">
           <label

--- a/i18n/locales/en.ts
+++ b/i18n/locales/en.ts
@@ -9,12 +9,22 @@ export default {
       getLocation: 'Get location',
     },
     warnings: {
-      latitude: 'Latitude must be between -90 and 90',
-      longitude: 'Longitude must be between -180 and 180',
+      latitude: {
+        'is-required': 'Latitude is required',
+        'range': 'Latitude must be between -90 and 90',
+      },
+      longitude: {
+        'is-required': 'Longitude is required',
+        'range': 'Longitude must be between -180 and 180',
+      },
+      startDate: {
+        'is-required': 'Start date is required',
+      },
       endDate: {
         'is-after-start': 'End date must be after start date',
         'is-at-least-6-weeks': 'End date must be at least 6 weeks later than start date',
         'is-max-one-year-range': 'Date range must not exceed 1 year',
+        'is-required': 'End date is required',
       },
     },
   },

--- a/i18n/locales/nl.ts
+++ b/i18n/locales/nl.ts
@@ -9,12 +9,22 @@ export default {
       getLocation: 'Locatie bepalen',
     },
     warnings: {
-      latitude: 'Breedtegraad moet tussen -90 en 90 liggen',
-      longitude: 'Lengtegraad moet tussen -180 en 180 liggen',
+      latitude: {
+        'is-required': 'Breedtegraad is verplicht',
+        'range': 'Breedtegraad moet tussen -90 en 90 liggen',
+      },
+      longitude: {
+        'is-required': 'Lengtegraad is verplicht',
+        'range': 'Lengtegraad moet tussen -180 en 180 liggen',
+      },
+      startDate: {
+        'is-required': 'Startdatum is verplicht',
+      },
       endDate: {
         'is-after-start': 'Einddatum moet na startdatum liggen',
         'is-at-least-6-weeks': 'Einddatum moet minstens 6 weken later zijn dan startdatum',
         'is-max-one-year-range': 'Periode mag niet langer zijn dan 1 jaar',
+        'is-required': 'Einddatum is verplicht',
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -50,7 +50,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       buildSha: undefined,
-      version: '1.2',
+      version: '1.3',
     },
   },
   compatibilityDate: '2024-11-01',


### PR DESCRIPTION
Enhanced start and end date validation by mapping error messages to specific keys for improved localization handling. Introduced tooltips for start and end date inputs to display validation errors dynamically. Updated translations in both English and Dutch to support the new error messages.