### PR TITLE
Restrict button click during simultaneous pending states

### DIFF
--- a/components/CoordinatesForm.vue
+++ b/components/CoordinatesForm.vue
@@ -192,7 +192,7 @@ watch(data, (newValue) => {
           <button
             class="btn btn-primary"
             type="button"
-            :disabled="!address || geocodingStatus === 'pending'"
+            :disabled="!address || geocodingStatus === 'pending' || status === 'pending'"
             @click="getCoordinatesForAddress()"
           >
             {{ $t('form.labels.findLocation') }}<span v-if="geocodingStatus === 'pending'">&nbsp;<FontAwesome


### PR DESCRIPTION
Add an additional condition to disable the button if `status` is `'pending'`, preventing potential issues when multiple pending states overlap. This ensures better user experience and avoids unintended behavior during geocoding operations.