### PR TITLE
Disable refetch on window focus and simplify error check.

### DIFF
--- a/src/components/InputForm.vue
+++ b/src/components/InputForm.vue
@@ -130,7 +130,7 @@ const onSubmit = handleSubmit(() => {
             :class="{ 'is-invalid': errors.address }"
           />
           <span
-            v-if="errors.address && !isLoadingData"
+            v-if="errors.address"
             ref="addressTooltipRef"
             class="popover bg-danger px-2 py-1 rounded-2 text-white"
             :style="addressTooltipStyles"

--- a/src/queries/geolocation-query.ts
+++ b/src/queries/geolocation-query.ts
@@ -8,6 +8,7 @@ const { VITE_GEOAPIFY_GEOLOCATION_API_BASE_URL: baseUrl, VITE_GEOAPIFY_API_KEY: 
 export const useGeolocationQuery = (text: Ref<string | null>) =>
   useQuery({
     enabled: computed(() => text.value != null),
+    refetchOnWindowFocus: false,
     queryKey: ['geolocation', text],
     queryFn: async () => {
       const response = await fetch(`${baseUrl}?text=${text.value}&format=json&apiKey=${apiKey}`, {

--- a/src/queries/reverse-geolocation-query.ts
+++ b/src/queries/reverse-geolocation-query.ts
@@ -12,6 +12,7 @@ export const useReverseGeolocationQuery = (
 ) =>
   useQuery({
     enabled: computed(() => lang.value != null && lat.value != null && lon.value != null),
+    refetchOnWindowFocus: false,
     queryKey: ['reverseGeolocation', lang, lat, lon],
     queryFn: async () => {
       const response = await fetch(

--- a/src/queries/sunset-query.ts
+++ b/src/queries/sunset-query.ts
@@ -16,6 +16,7 @@ export const useSunsetQuery = (
       () =>
         lat.value != null && lon.value != null && startDate.value != null && endDate.value != null,
     ),
+    refetchOnWindowFocus: false,
     queryKey: ['sunset', lat, lon, startDate, endDate],
     queryFn: async () => {
       const response = await fetch(


### PR DESCRIPTION
Disabled `refetchOnWindowFocus` for sunset, geolocation, and reverse geolocation queries to prevent unnecessary network calls. Simplified the address error display condition in `InputForm.vue` for better maintainability.