### PR TITLE
Update build scripts, workflows, and add Bootswatch dependency

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 VITE_GEOAPIFY_GEOLOCATION_API_BASE_URL=https://api.geoapify.com/v1/geocode/search
 VITE_GEOAPIFY_REVERSE_GEOLOCATION_API_BASE_URL=https://api.geoapify.com/v1/geocode/reverse
 VITE_SUNSET_API_BASE_URL=https://api.sunrisesunset.io/json
-VITE_VERSION=1.0
+VITE_APP_VERSION=1.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
       - run: |
           echo "VITE_BUILD_SHA=$(git rev-parse --short HEAD)" | tee -a $GITHUB_WORKSPACE/.env.local
           echo "VITE_GEOAPIFY_API_KEY=${{ secrets.GEOAPIFY_API_KEY }}" | tee -a $GITHUB_WORKSPACE/.env.local
-      - run: pnpm build-only --base /${{ github.event.repository.name }}/
+      - run: pnpm build --base /${{ github.event.repository.name }}/
       - uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist

--- a/.github/workflows/services.yml
+++ b/.github/workflows/services.yml
@@ -64,7 +64,7 @@ jobs:
       - run: |
           echo "VITE_BUILD_SHA=e2e" | tee -a $GITHUB_WORKSPACE/.env.local
           echo "VITE_GEOAPIFY_API_KEY=${{ secrets.GEOAPIFY_API_KEY }}" | tee -a $GITHUB_WORKSPACE/.env.local
-      - run: pnpm build-only
+      - run: pnpm build
       - run: pnpm test:e2e
         env:
           HOME: /root

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test'
 
+const buildSha = process.env.CI ? 'e2e' : 'dev'
+
 test('header should contain "Daylight Visualizer"', async ({ page }) => {
   await page.goto('/')
   await expect(page.locator('h1')).toContainText('Daylight Visualizer')
+})
+
+test(`version should be "${buildSha}"`, async ({ page }) => {
+  await page.goto('/')
+  await expect(page.locator('h1 > span')).toContainText(`- ${buildSha}`)
 })

--- a/package.json
+++ b/package.json
@@ -5,15 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "run-p type-check \"build-only {@}\" --",
+    "build": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
-    "build-only": "vite build",
-    "type-check": "vue-tsc --build",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "format": "prettier --write src/",
     "prepare": "husky"
   },
   "dependencies": {
@@ -28,6 +25,7 @@
     "@tanstack/vue-query-devtools": "^5.66.9",
     "@vee-validate/yup": "^4.15.0",
     "bootstrap": "^5.3.3",
+    "bootswatch": "^5.3.3",
     "highcharts": "^12.1.2",
     "highcharts-vue": "^2.0.1",
     "luxon": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.3(@popperjs/core@2.11.8)
+      bootswatch:
+        specifier: ^5.3.3
+        version: 5.3.3
       highcharts:
         specifier: ^12.1.2
         version: 12.1.2
@@ -1148,6 +1151,9 @@ packages:
     resolution: {integrity: sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==}
     peerDependencies:
       '@popperjs/core': ^2.11.8
+
+  bootswatch@5.3.3:
+    resolution: {integrity: sha512-cJLhobnZsVCelU7zdH/L7wpcXAyUoTX4/5l2dWQ0JXgaVK80BdTQNU/ImWwoyIGBeyms4iQDAdNtOfPQZf0Atg==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3629,6 +3635,8 @@ snapshots:
   bootstrap@5.3.3(@popperjs/core@2.11.8):
     dependencies:
       '@popperjs/core': 2.11.8
+
+  bootswatch@5.3.3: {}
 
   brace-expansion@1.1.11:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@ import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 import { faSun } from '@fortawesome/free-solid-svg-icons'
 import MainContent from '@/components/MainContent.vue'
 
-const { VITE_BUILD_SHA: buildSha, VITE_VERSION: version } = import.meta.env
+const { VITE_BUILD_SHA: buildSha, VITE_APP_VERSION: version } = import.meta.env
 </script>
 
 <template>

--- a/src/assets/styles/_bootstrap.scss
+++ b/src/assets/styles/_bootstrap.scss
@@ -10,6 +10,7 @@ $enable-validation-icons: false;
 //$blue: #2274a5;
 //$red: #9b1d20;
 //$green: #1c7c54;
+@import "bootswatch/dist/quartz/variables";
 
 // 3. Include remainder of required Bootstrap stylesheets (including any separate color mode stylesheets)
 @import "bootstrap/scss/variables";
@@ -35,6 +36,7 @@ $enable-validation-icons: false;
 @import "bootstrap/scss/utilities/api";
 
 // 8. Add additional custom code here
+@import "bootswatch/dist/quartz/bootswatch";
 input.is-invalid + .popover {
   font-size: .75rem;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import '@fontsource/palanquin/latin-500.css'
+import '@fontsource/palanquin/latin-700.css'
 import '@fontsource/oxygen/latin-400.css'
 import '@fontsource/fira-mono/400.css'
 


### PR DESCRIPTION
Replaced "build-only" script with "build" for simplicity and updated workflows to reflect the change. Added the "bootswatch" package as a new dependency and updated the `pnpm-lock.yaml` to include it. This ensures better consistency across build processes and extends theme options with Bootswatch.